### PR TITLE
feat: add ssh helper script

### DIFF
--- a/device-mgmt/ssh_hosts.conf
+++ b/device-mgmt/ssh_hosts.conf
@@ -1,0 +1,6 @@
+# Device IP addresses for sshh.sh
+laptop=192.168.1.217
+desktop=192.168.1.237
+pib4=192.168.1.198
+piw0=192.168.1.78
+windesktop=192.168.1.68

--- a/device-mgmt/sshh.sh
+++ b/device-mgmt/sshh.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# sshh.sh - connect to local devices via SSH using stored credentials.
+#
+# Usage:
+#   sshh.sh [--config] <target>
+#
+# With --config, opens the configuration file in nvim for editing.
+
+set -euo pipefail
+
+CONFIG_FILE="$(dirname "${BASH_SOURCE[0]}")/ssh_hosts.conf"
+USER="braydenchaffee"
+PASSWORD="0323"
+
+usage() {
+  echo "Usage: $0 [--config] <target>"
+  echo "Available targets are defined in $CONFIG_FILE"
+}
+
+if [[ ${1-} == "--config" ]]; then
+  nvim "$CONFIG_FILE"
+  exit 0
+fi
+
+TARGET=${1-}
+if [[ -z "$TARGET" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Config file not found: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+IP="${!TARGET:-}"
+if [[ -z "$IP" ]]; then
+  echo "Unknown target: $TARGET" >&2
+  exit 1
+fi
+
+sshpass -p "$PASSWORD" ssh "$USER@$IP"


### PR DESCRIPTION
## Summary
- add sshh.sh to connect to local devices using stored credentials
- store device IPs in editable ssh_hosts.conf

## Testing
- `shellcheck device-mgmt/sshh.sh`
- `bash device-mgmt/sshh.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a2a6a2d72083298c55773f4d556257